### PR TITLE
Rename climbing helpers to avoid mapping conflicts

### DIFF
--- a/common/src/main/java/com/starfish_studios/naturalist/client/model/SnailModel.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/client/model/SnailModel.java
@@ -63,7 +63,7 @@ public class SnailModel extends GeoModel<Snail> {
             eyes.setScaleZ(1.0F);
         }
 
-        if (!animatable.isClimbing() || !animatable.canHide()) {
+        if (!animatable.isNaturalistClimbing() || !animatable.canHide()) {
             leftEye.setRotX(extraDataOfType.headPitch() * Mth.DEG_TO_RAD);
             leftEye.setRotY(extraDataOfType.netHeadYaw() * Mth.DEG_TO_RAD);
             rightEye.setRotX(extraDataOfType.headPitch() * Mth.DEG_TO_RAD);

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snail.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snail.java
@@ -403,7 +403,7 @@ public class Snail extends ClimbingAnimal implements NaturalistGeoEntity, Bucket
     private <E extends Snail> PlayState predicate(final @NotNull AnimationState<E> event) {
         if (this.getDeltaMovement().horizontalDistanceSqr() > 1.0E-6) {
             event.getController().setAnimation(CRAWL);
-        } else if (this.isClimbing()){
+        } else if (this.isNaturalistClimbing()){
             event.getController().setAnimation(CLIMB);
         } else {
             event.getController().setAnimation(IDLE);

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snake.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snake.java
@@ -419,7 +419,7 @@ public class Snake extends ClimbingAnimal implements SleepingAnimal, NeutralMob,
         if (this.isSleeping()) {
             event.getController().setAnimation(SLEEP);
             return PlayState.CONTINUE;
-        } else if (this.isClimbing()) {
+        } else if (this.isNaturalistClimbing()) {
             event.getController().setAnimation(CLIMB);
             return PlayState.CONTINUE;
         } else if (!(event.getLimbSwingAmount() > -0.04F && event.getLimbSwingAmount() < 0.04F)) {

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/ClimbingAnimal.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/ClimbingAnimal.java
@@ -32,7 +32,7 @@ public abstract class ClimbingAnimal extends NaturalistAnimal {
     public void tick() {
         super.tick();
         if (!this.level().isClientSide) {
-            this.setClimbing(this.horizontalCollision);
+            this.setNaturalistClimbing(this.horizontalCollision);
         }
         if (this.horizontalCollision && this.onClimbable()) {
             this.setDeltaMovement(this.getDeltaMovement().x, this.getDeltaMovement().y * this.getClimbSpeedMultiplier(), this.getDeltaMovement().z);
@@ -41,16 +41,16 @@ public abstract class ClimbingAnimal extends NaturalistAnimal {
 
     @Override
     public boolean onClimbable() {
-        return this.isClimbing();
+        return this.isNaturalistClimbing();
     }
 
-    public boolean isClimbing() {
+    public boolean isNaturalistClimbing() {
         return (this.entityData.get(CLIMB_FLAG) & 1) != 0;
     }
 
-    public void setClimbing(boolean pClimbing) {
+    public void setNaturalistClimbing(boolean climbing) {
         byte flag = this.entityData.get(CLIMB_FLAG);
-        if (pClimbing) {
+        if (climbing) {
             flag = (byte)(flag | 1);
         } else {
             flag = (byte)(flag & -2);


### PR DESCRIPTION

- rename `ClimbingAnimal` climbing helpers to avoid conflict with Minecraft mappings
- update snail, snake, and model code to use the new names

